### PR TITLE
♻️ separate out refresh and send notification routes

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/controllers/NotificationController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/controllers/NotificationController.kt
@@ -35,8 +35,14 @@ class NotificationController(val notificationService: NotificationService) {
     }
 
     @GetMapping("/notifications/refresh")
-    fun sendNotifications(): ResponseEntity<Collection<NotificationDto>> {
-        notificationService.refreshNotifications()
+    fun refreshNotifications(): ResponseEntity<Unit> {
+        notificationService.generateAndSaveNotifications()
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/notifications/send")
+    fun sendNotifications(): ResponseEntity<Unit> {
+        notificationService.sendNotifications()
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/service/NotificationService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/service/NotificationService.kt
@@ -142,9 +142,9 @@ class NotificationService(
     private fun sendNotification(quantumId: String, notificationGroup: List<ShiftNotification>) {
         val userPreference = userPreferenceService.getOrCreateUserPreference(quantumId)
 
-        data class Key(val shiftDate: LocalDateTime, val shiftType: String)
+        data class Key(val shiftDate: LocalDateTime, val shiftType: String, val quantumId: String)
 
-        fun ShiftNotification.toKeyDuplicates() = Key(this.shiftDate, this.shiftType)
+        fun ShiftNotification.toKeyDuplicates() = Key(this.shiftDate, this.shiftType, this.quantumId)
 
         val mostRecentNotifications = notificationGroup
                 .groupBy { it.toKeyDuplicates() }

--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/service/NotificationService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/service/NotificationService.kt
@@ -148,7 +148,9 @@ class NotificationService(
 
         val mostRecentNotifications = notificationGroup
                 .groupBy { it.toKeyDuplicates() }
-                .map { (key, value) -> value.sortedByDescending { it.shiftModified }.elementAt(0) }
+                .map { (key, value) -> value.maxBy { it.shiftModified } }
+                .filterNotNull()
+
 
         if (shouldSend(userPreference)) {
             log.debug("Sending (${mostRecentNotifications.size}) notifications to ${userPreference.quantumId}, preference set to ${userPreference.commPref}")


### PR DESCRIPTION
- separate out generating and sending notifications
- only send most recent notification from DB