### PR TITLE
🐛 base 64 wraps text at char 76, we don't want that as it's making th…

### DIFF
--- a/helm_deploy/cmd-api/templates/cronjob-shift-changes.yaml
+++ b/helm_deploy/cmd-api/templates/cronjob-shift-changes.yaml
@@ -20,6 +20,6 @@ spec:
             image: quay.io/ukhomeofficedigital/openjdk11
             command: ["/bin/sh", "-c"]
             args:
-              - 'JWT=$(curl -X POST {{ .Values.env.OAUTH_ROOT_URL }}/oauth/token?grant_type=client_credentials -H "Content-Type: application/json" -H "Content-Length: 0" -H "Authorization: Basic $(echo -n ''{{ .Values.secrets.API_CLIENT_ID }}:{{ .Values.secrets.API_CLIENT_SECRET }}'' | base64)"); TOKEN=$(echo -n $JWT | grep -o -E ''[-a-zA-Z0-9\._]{100,}''); curl http://cmd-api.{{ .Values.cron.namespace }}.svc.cluster.local/notifications/refresh -H "Authorization: Bearer $(echo -n $TOKEN)";'
+              - 'JWT=$(curl -X POST {{ .Values.env.OAUTH_ROOT_URL }}/oauth/token?grant_type=client_credentials -H "Content-Type: application/json" -H "Content-Length: 0" -H "Authorization: Basic $(echo -n ''{{ .Values.secrets.API_CLIENT_ID }}:{{ .Values.secrets.API_CLIENT_SECRET }}'' | base64 -w 0)"); TOKEN=$(echo -n $JWT | grep -o -E ''[-a-zA-Z0-9\._]{100,}''); curl http://cmd-api.{{ .Values.cron.namespace }}.svc.cluster.local/notifications/refresh -H "Authorization: Bearer $(echo -n $TOKEN)";'
           restartPolicy: Never
           activeDeadlineSeconds: 5400


### PR DESCRIPTION
…e token invalid.