### PR TITLE
🐛 Identify full day activities for shift task descriptions

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescription.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescription.kt
@@ -13,7 +13,7 @@ class NotificationDescription {
 
             val bulletPoint = getOptionalBulletPoint(communicationPreference)
             val date = getDateTimeFormattedForTemplate(shiftNotification.shiftDate, clock)
-            val taskTime = getOptionalTaskDescription(shiftNotification.taskStart, shiftNotification.taskEnd)
+            val taskTime = getOptionalTaskDescription(shiftNotification.taskStart, shiftNotification.taskEnd, shiftNotification.task)
             val shiftActionType = ShiftActionType.from(shiftNotification.actionType)
             val taskTo = getOptionalTaskTo(shiftNotification.task, communicationPreference, shiftActionType)
             val shiftNotificationType = ShiftNotificationType.from(shiftNotification.shiftType)
@@ -38,16 +38,19 @@ class NotificationDescription {
             return DateTimeFormatter.ofPattern("EEEE, d'$ordinal' MMMM$year").format(shiftDate)
         }
 
-        private fun getOptionalTaskDescription(from: Long?, to: Long?): String {
-            return if (from != null && from != 0L && to != null && to != 0L) {
-                if((from > LocalTime.MAX.toSecondOfDay() || from < LocalTime.MIN.toSecondOfDay()) ||
-                    (to > LocalTime.MAX.toSecondOfDay() || to < LocalTime.MIN.toSecondOfDay())) {
-                    "(full day) "
-                } else {
-                    val fromTime = LocalTime.ofSecondOfDay(from)
-                    val toTime = LocalTime.ofSecondOfDay(to)
-                    "($fromTime - $toTime) "
-                }
+        private fun getOptionalTaskDescription(from: Long?, to: Long?, task: String?): String {
+             return if (from != null && to != null)
+             {
+                 if(from > 1000L && to > 1000L) {
+                     val fullDay = 86400L
+                     val startTime = LocalTime.ofSecondOfDay(if(from > fullDay) { from - fullDay } else { from })
+                     val endTime = LocalTime.ofSecondOfDay(if(to > fullDay) { to - fullDay } else { to })
+                     "($startTime - $endTime) "
+                 } else if(!task.isNullOrEmpty()){
+                     "(full day) "
+                 } else {
+                     ""
+                 }
             } else ""
         }
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescription.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescription.kt
@@ -39,19 +39,25 @@ class NotificationDescription {
         }
 
         private fun getOptionalTaskDescription(from: Long?, to: Long?, task: String?): String {
-             return if (from != null && to != null)
+             return if ((from != null && to != null) && !task.isNullOrEmpty())
              {
                  if(from > 1000L && to > 1000L) {
-                     val fullDay = 86400L
-                     val startTime = LocalTime.ofSecondOfDay(if(from > fullDay) { from - fullDay } else { from })
-                     val endTime = LocalTime.ofSecondOfDay(if(to > fullDay) { to - fullDay } else { to })
-                     "($startTime - $endTime) "
-                 } else if(!task.isNullOrEmpty()){
-                     "(full day) "
+                     "(${getTimeWithoutDayOffset(from)} - ${getTimeWithoutDayOffset(to)}) "
                  } else {
-                     ""
+                     "(full day) "
                  }
             } else ""
+        }
+
+        private fun getTimeWithoutDayOffset(seconds: Long): LocalTime {
+            val fullDay = 86_400L
+            return LocalTime.ofSecondOfDay(
+                    if (seconds > fullDay) {
+                        seconds - fullDay
+                    } else {
+                        seconds
+                    }
+            )
         }
 
         private fun getOptionalTaskTo(task: String?, communicationPreference: CommunicationPreference, shiftActionType: ShiftActionType): String {

--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescription.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescription.kt
@@ -40,9 +40,14 @@ class NotificationDescription {
 
         private fun getOptionalTaskDescription(from: Long?, to: Long?): String {
             return if (from != null && from != 0L && to != null && to != 0L) {
-                val fromTime = LocalTime.ofSecondOfDay(from)
-                val toTime = LocalTime.ofSecondOfDay(to)
-                "($fromTime - $toTime) "
+                if((from > LocalTime.MAX.toSecondOfDay() || from < LocalTime.MIN.toSecondOfDay()) ||
+                    (to > LocalTime.MAX.toSecondOfDay() || to < LocalTime.MIN.toSecondOfDay())) {
+                    "(full day) "
+                } else {
+                    val fromTime = LocalTime.ofSecondOfDay(from)
+                    val toTime = LocalTime.ofSecondOfDay(to)
+                    "($fromTime - $toTime) "
+                }
             } else ""
         }
 

--- a/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescriptionTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescriptionTest.kt
@@ -19,6 +19,38 @@ class NotificationDescriptionTest {
     private val now = LocalDate.now(clock)
 
     @Nested
+    @DisplayName("Shift Task boundary checks")
+    inner class ShitTaskBoundary {
+        @Test
+        fun `Should return full day for from less than 0 `() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, -1234L, 12345L, "Test Duty", "shift_task", "edit", false)
+            val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
+            assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
+        }
+
+        @Test
+        fun `Should return full day for to less than 0 `() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 1234L, -12345L, "Test Duty", "shift_task", "edit", false)
+            val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
+            assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
+        }
+
+        @Test
+        fun `Should return full day for from more than 86400 `() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 1234L, 87345L, "Test Duty", "shift_task", "edit", false)
+            val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
+            assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
+        }
+
+        @Test
+        fun `Should return full day for to more than 86400 `() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 87234L, 12345L, "Test Duty", "shift_task", "edit", false)
+            val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
+            assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
+        }
+    }
+
+    @Nested
     @DisplayName("Shift, Edit, This year tests")
     inner class ShiftEditThisYear {
         @Test

--- a/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescriptionTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/domain/NotificationDescriptionTest.kt
@@ -12,7 +12,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 
-
 class NotificationDescriptionTest {
 
     private val clock = Clock.fixed(LocalDate.of(2020, 5, 3).atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault())
@@ -22,31 +21,38 @@ class NotificationDescriptionTest {
     @DisplayName("Shift Task boundary checks")
     inner class ShitTaskBoundary {
         @Test
-        fun `Should return full day for from less than 0 `() {
-            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, -1234L, 12345L, "Test Duty", "shift_task", "edit", false)
+        fun `Should return full day for 0 0 `() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 0L, 0L, "Test Duty", "shift_task", "edit", false)
             val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
             assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
         }
 
         @Test
-        fun `Should return full day for to less than 0 `() {
-            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 1234L, -12345L, "Test Duty", "shift_task", "edit", false)
+        fun `Should return full day for -2147483648 -2147483648 `() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, -2147483648L, -2147483648L, "Test Duty", "shift_task", "edit", false)
             val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
             assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
         }
 
         @Test
-        fun `Should return full day for from more than 86400 `() {
-            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 1234L, 87345L, "Test Duty", "shift_task", "edit", false)
+        fun `Should return full day for 0 86400`() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 0L, 86400L, "Test Duty", "shift_task", "edit", false)
             val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
             assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
         }
 
         @Test
-        fun `Should return full day for to more than 86400 `() {
-            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 87234L, 12345L, "Test Duty", "shift_task", "edit", false)
+        fun `Should return full day for 0 86700`() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 0L, 86700L, "Test Duty", "shift_task", "edit", false)
             val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
             assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (full day) has changed to Test Duty.")
+        }
+
+        @Test
+        fun `Should return night hours for 73800 113400`() {
+            val shiftNotification = ShiftNotification(1, "", now, LocalDateTime.MIN, 73800L, 113400L, "Test Duty", "shift_task", "edit", false)
+            val result = NotificationDescription.getNotificationDescription(shiftNotification, CommunicationPreference.NONE, clock)
+            assertThat(result).isEqualTo("Your activity on Sunday, 3rd May (20:30 - 07:30) has changed to Test Duty.")
         }
     }
 

--- a/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/dto/NotificationDtoTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/dto/NotificationDtoTest.kt
@@ -31,7 +31,7 @@ class NotificationDtoTest {
         Assertions.assertThat(notificationDtos).hasSize(1)
 
         val first = notificationDtos[0]
-        Assertions.assertThat(first.description).isEqualTo("Your shift on Sunday, 3rd May (00:02:03 - 00:07:36) has been added as Any Activity.")
+        Assertions.assertThat(first.description).isEqualTo("Your activity on Sunday, 3rd May (full day) has been added as Any Activity.")
         Assertions.assertThat(first.shiftModified).isEqualTo(shifts[0].shiftModified)
         Assertions.assertThat(first.processed).isEqualTo(shifts[0].processed)
     }
@@ -83,7 +83,7 @@ class NotificationDtoTest {
             val taskStart = 123L
             val taskEnd = 456L
             val task = "Any Activity"
-            val shiftType = "shift"
+            val shiftType = "shift_task"
             val actionType = "add"
 
             val processed = false


### PR DESCRIPTION
CSR uses numbers like -2147483648 to mean full day, we were passing this to LocalTime.ofSecondOfDay() and it was throwing java.time.DateTimeException.