### PR TITLE
🐛 Be more granular around marking notifications as processed.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,9 +10,7 @@ spring:
 
   datasource:
     hikari:
-      maximum-pool-size: 25
-      connectionTimeout: 2000
-      validationTimeout:  500
+      maximum-pool-size: 15
 
 server:
   port: 8080


### PR DESCRIPTION
+ use Hikari default values.


At the moment because of where the try catch block is if we get a problem, a larger number of notifications don't get processed that is necessary. Move the try catch block down to the email/sms in question