### PR TITLE
PAT-2035 Refactor CMD notification jobs - adjust schedule after csr-api shift call speedup

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/controllers/NotificationRefreshQuartzJob.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/controllers/NotificationRefreshQuartzJob.java
@@ -13,8 +13,6 @@ public class NotificationRefreshQuartzJob implements Job {
     private NotificationService service;
 
     public void execute(JobExecutionContext context) {
-        service.refreshNotifications(6);
-        service.sendNotifications();
         service.refreshNotifications(1);
         service.sendNotifications();
         service.refreshNotifications(2);
@@ -24,6 +22,8 @@ public class NotificationRefreshQuartzJob implements Job {
         service.refreshNotifications(4);
         service.sendNotifications();
         service.refreshNotifications(5);
+        service.sendNotifications();
+        service.refreshNotifications(6);
         service.sendNotifications();
     }
 }


### PR DESCRIPTION
As the job can take over an hour, change to run it every 1.5 hours. We cant allow concurrent threads running sendNotifications() as this will result in duplicate emails/texts