### PR TITLE
SDI-110 Add timeouts to blocking web client calls

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/client/CsrClient.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/cmd/api/client/CsrClient.kt
@@ -3,15 +3,18 @@ package uk.gov.justice.digital.hmpps.cmd.api.client
 import com.fasterxml.jackson.annotation.JsonCreator
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.cmd.api.domain.DetailModificationType
 import uk.gov.justice.digital.hmpps.cmd.api.domain.ShiftType
 import uk.gov.justice.digital.hmpps.cmd.api.security.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.cmd.api.utils.region.Regions
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -20,7 +23,8 @@ class CsrClient(
   @Qualifier("csrApiWebClient") private val csrClient: WebClient,
   @Qualifier("csrAPIWebClientAppScope") private val csrApiServiceAccountWebClient: WebClient,
   private val authenticationFacade: AuthenticationFacade,
-  private val regionData: Regions
+  private val regionData: Regions,
+  @Value("\${csr.timeout}") private val csrApiTimeout: Duration,
 ) {
 
   @Cacheable(
@@ -49,6 +53,7 @@ class CsrClient(
       .uri("/updates/$region")
       .retrieve()
       .bodyToMono(object : ParameterizedTypeReference<List<CsrModifiedDetailDto>>() {})
+      .timeout(csrApiTimeout, Mono.just(emptyList()))
       .block() ?: emptyList()
     log.info("getModified: found ${csrModifiedDetails.size}, Region $region")
     return csrModifiedDetails
@@ -64,6 +69,7 @@ class CsrClient(
       .bodyValue(ids)
       .retrieve()
       .bodyToMono(Unit::class.java)
+      .timeout(csrApiTimeout)
       .block()
 
     log.info("deleteProcessed: end, Region $region")
@@ -76,6 +82,7 @@ class CsrClient(
       .uri("/user/details/$region?from=$from&to=$to")
       .retrieve()
       .bodyToMono(CSR_DETAIL_DTO_LIST_TYPE)
+      .timeout(csrApiTimeout, Mono.just(emptyList()))
       .block() ?: listOf()
     log.info("User Details: found ${csrDetails.size}, User ${authenticationFacade.currentUsername}, $from - $to, Region $region")
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,3 +84,4 @@ csr:
     - name: 4
     - name: 5
     - name: 6
+  timeout: 10m

--- a/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/scheduler/PollingSchedulerIntegrationTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/scheduler/PollingSchedulerIntegrationTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.cmd.api.scheduler
 
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -19,7 +22,7 @@ import java.time.Clock
 import java.time.LocalDateTime
 
 @ExtendWith(PrisonApiExtension::class, CsrApiExtension::class, HmppsAuthApiExtension::class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["csr.timeout=1s"])
 @ActiveProfiles(value = ["test"])
 @DisplayName("Integration Tests for Shift Controller")
 class PollingSchedulerIntegrationTest(
@@ -150,6 +153,90 @@ class PollingSchedulerIntegrationTest(
     val all = dryRunNotificationRepository.findAll()
     assertThat(all).asList().hasSize(1)
     assertThat(all.first().quantumId).isEqualTo("user2")
+  }
+
+  @Test
+  fun `handles connection reset by peer errors`() {
+    CsrApiExtension.api.stubGetUpdates(
+      1,
+      """
+      [
+        {
+        "id" : "101",
+        "quantumId" : "$A_USER",
+        "shiftModified" : "2022-03-25T15:00:00",
+        "shiftType" : "SHIFT",
+        "detailStart" : "2022-03-31T10:00:00",
+        "detailEnd" : "2022-03-31T11:00:00",
+        "activity" : "CCTV monitoring",
+        "actionType" : "ADD"
+        },
+        {
+        "id" : "103",
+        "shiftModified" : "2022-03-25T15:30:00",
+        "shiftType" : "SHIFT",
+        "detailStart" : "2022-03-31T10:00:00",
+        "detailEnd" : "2022-03-31T11:00:00",
+        "activity" : "CCTV monitoring",
+        "actionType" : "ADD"
+        }
+      ]
+      """.trimIndent()
+    )
+    CsrApiExtension.api.stubConnectionResetByPeer(2)
+    CsrApiExtension.api.stubGetUpdates(3, """[{
+        "id" : "102",
+        "quantumId" : "other-user",
+        "shiftModified" : "2022-03-25T15:40:00",
+        "shiftType" : "SHIFT",
+        "detailStart" : "2022-03-31T10:00:00",
+        "detailEnd" : "2022-03-31T11:00:00",
+        "activity" : "CCTV monitoring",
+        "actionType" : "ADD"
+        }]""")
+    CsrApiExtension.api.stubGetUpdates(4, "[]")
+    CsrApiExtension.api.stubGetUpdates(5, "[]")
+    CsrApiExtension.api.stubGetUpdates(6, "[]")
+    CsrApiExtension.api.stubDeleteProcessed(1, "[101,103]")
+    CsrApiExtension.api.stubDeleteProcessed(3, "[102]")
+
+    pollingScheduler.pollNotifications()
+
+    assertThat(CsrApiExtension.api.putCountFor("/updates/1")).isEqualTo(1)
+    assertThat(CsrApiExtension.api.putCountFor("/updates/2")).isEqualTo(0)
+    assertThat(CsrApiExtension.api.putCountFor("/updates/3")).isEqualTo(1)
+    assertThat(CsrApiExtension.api.putCountFor("/updates/4")).isEqualTo(0)
+    assertThat(CsrApiExtension.api.putCountFor("/updates/5")).isEqualTo(0)
+    assertThat(CsrApiExtension.api.putCountFor("/updates/6")).isEqualTo(0)
+    CsrApiExtension.api.verify(putRequestedFor(urlEqualTo("/updates/1")).withRequestBody(equalTo("[101,103]")))
+    CsrApiExtension.api.verify(putRequestedFor(urlEqualTo("/updates/3")).withRequestBody(equalTo("[102]")))
+
+
+    val saved = dryRunNotificationRepository.findAll()
+    assertThat(saved).asList().containsExactly(
+      DryRunNotification(
+        id = saved.first().id, // generated
+        quantumId = A_USER,
+        shiftModified = LocalDateTime.parse("2022-03-25T15:00:00"),
+        detailStart = LocalDateTime.parse("2022-03-31T10:00:00"),
+        detailEnd = LocalDateTime.parse("2022-03-31T11:00:00"),
+        activity = "CCTV monitoring",
+        actionType = DetailModificationType.ADD,
+        parentType = ShiftType.SHIFT,
+        processed = true,
+      ),
+      DryRunNotification(
+        id = saved.last().id,
+        quantumId = "other-user",
+        shiftModified = LocalDateTime.parse("2022-03-25T15:40:00"),
+        detailStart = LocalDateTime.parse("2022-03-31T10:00:00"),
+        detailEnd = LocalDateTime.parse("2022-03-31T11:00:00"),
+        activity = "CCTV monitoring",
+        actionType = DetailModificationType.ADD,
+        parentType = ShiftType.SHIFT,
+        processed = true,
+      ),
+    )
   }
 
   companion object {

--- a/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/scheduler/PollingSchedulerIntegrationTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/scheduler/PollingSchedulerIntegrationTest.kt
@@ -184,7 +184,9 @@ class PollingSchedulerIntegrationTest(
       """.trimIndent()
     )
     CsrApiExtension.api.stubConnectionResetByPeer(2)
-    CsrApiExtension.api.stubGetUpdates(3, """[{
+    CsrApiExtension.api.stubGetUpdates(
+      3,
+      """[{
         "id" : "102",
         "quantumId" : "other-user",
         "shiftModified" : "2022-03-25T15:40:00",
@@ -193,7 +195,8 @@ class PollingSchedulerIntegrationTest(
         "detailEnd" : "2022-03-31T11:00:00",
         "activity" : "CCTV monitoring",
         "actionType" : "ADD"
-        }]""")
+        }]"""
+    )
     CsrApiExtension.api.stubGetUpdates(4, "[]")
     CsrApiExtension.api.stubGetUpdates(5, "[]")
     CsrApiExtension.api.stubGetUpdates(6, "[]")
@@ -210,7 +213,6 @@ class PollingSchedulerIntegrationTest(
     assertThat(CsrApiExtension.api.putCountFor("/updates/6")).isEqualTo(0)
     CsrApiExtension.api.verify(putRequestedFor(urlEqualTo("/updates/1")).withRequestBody(equalTo("[101,103]")))
     CsrApiExtension.api.verify(putRequestedFor(urlEqualTo("/updates/3")).withRequestBody(equalTo("[102]")))
-
 
     val saved = dryRunNotificationRepository.findAll()
     assertThat(saved).asList().containsExactly(

--- a/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/wiremock/CsrMockServer.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/cmd/api/wiremock/CsrMockServer.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.http.Fault
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -88,6 +89,15 @@ class CsrMockServer : WireMockServer(WIREMOCK_PORT) {
             .withHeader("Content-Type", "application/json")
             .withStatus(200)
         )
+    )
+  }
+
+  fun stubConnectionResetByPeer(region: Int) {
+    stubFor(
+      get("/updates/$region").willReturn(
+        aResponse()
+          .withFault(Fault.CONNECTION_RESET_BY_PEER)
+      )
     )
   }
 


### PR DESCRIPTION
When getting a connection reset error during a blocking call control was never returned to the WebClient and the scheduler thread hangs. A timeout prevents that from occurring as a TimeoutException is fired instead.